### PR TITLE
allow empty description

### DIFF
--- a/gcal-import-worker.php
+++ b/gcal-import-worker.php
@@ -176,10 +176,14 @@ function gcal_import_do_import($category, $link) {
         }
 
         // geocoden
-        $location = urldecode ($r['LOCATION']);
-        $my_latlon = gcal_import_geocode($location);
-        $file = dirname (__FILE__) . "/latlon-$hash.txt";
-        file_put_contents ($file, var_export ($my_latlon, TRUE));
+        $options = get_option('gcal_options');
+        if ( $options['gcal_geocoding'] != "off" ) {
+
+                $location = urldecode ($r['LOCATION']);
+                $my_latlon = gcal_import_geocode($location);
+                $file = dirname (__FILE__) . "/latlon-$hash.txt";
+                file_put_contents ($file, var_export ($my_latlon, TRUE));
+        }
 
         // create a default form
 //         $post = get_default_post_to_edit ('termine', false);

--- a/gcal-import-worker.php
+++ b/gcal-import-worker.php
@@ -229,13 +229,13 @@ function gcal_import_do_import($category, $link) {
 
         // and fill in the post form
         $post->post_author = '1';
-        $post->post_content = $r['DESCRIPTION'];
+        $post->post_content = $r['DESCRIPTION'] ?: '';
         $post->post_title = $r['SUMMARY'];
         // create an excerpt for the overview page ([wpcalendar kat=...])
-        if (strlen ($r['DESCRIPTION']) > 160) {
-            $post->post_excerpt = substr ($r['DESCRIPTION'], 0, 160) . ' ...'; // first 160 chars of DESCRIPTION plus ' ...'
+        if (strlen ($post->post_content) > 160) {
+            $post->post_excerpt = substr ($post->post_content, 0, 160) . ' ...'; // first 160 chars of DESCRIPTION plus ' ...'
         } else {
-            $post->post_excerpt = $r['DESCRIPTION'];
+            $post->post_excerpt = $post->post_content;
         }
         $post->post_status = 'publish';
         $post->post_category = array ($category,); 


### PR DESCRIPTION
other ics sources may not contain an "DESCRIPTION" attribute if is empty, which makes kal3000-gcal-import choke with a SQL error. Adding a ternary operator to include an empty string in such a case
(sorry this also includes a copy of my previous PR as I created a new branch too late...)